### PR TITLE
fix(vcw/efw): show toolbar if not visible (matlab 2025+)

### DIFF
--- a/lib/efw.m
+++ b/lib/efw.m
@@ -45,6 +45,10 @@ end
 
 %% Initialise button
 hb = findall(hf,'Tag','FigureToolBar'); % hb = findall(hf,'Type','uitoolbar');
+if isempty(hb)
+    set(hf, 'ToolBar', 'figure');
+    hb = findall(hf,'Tag','FigureToolBar');
+end
 
 %Check for presence of a efw button
 hp = findobj(hb,'Tag','efw_button');

--- a/lib/vcw.m
+++ b/lib/vcw.m
@@ -118,6 +118,10 @@ end
 
 %% Initialise button and button/keypress wait
 hb = findall(hf,'Tag','FigureToolBar'); % hb = findall(hf,'Type','uitoolbar');
+if isempty(hb)
+    set(hf, 'ToolBar', 'figure');
+    hb = findall(hf,'Tag','FigureToolBar');
+end
 
 %Check for presence of a vcw button
 hp = findobj(hb,'Tag','tBar');


### PR DESCRIPTION
Closes #196

Similar to the fix proposed in #195. That one creates a new (blank) `uitoolbar`, whereas this one tells MATLAB to display the default figure toolbar (as it did before by default).

You'd hope there'd be a big red flag in the release docs, but [this](https://uk.mathworks.com/matlabcentral/answers/2180850-why-can-i-not-see-the-menu-bar-file-edit-view-etc-when-i-open-my-guide-built-app-in-r2025a-or#answer_1571397) is the closest I could find to official docs documenting the change.