### PR TITLE
rev setViewProfile

### DIFF
--- a/lib/gibbonSettings.m
+++ b/lib/gibbonSettings.m
@@ -113,10 +113,21 @@ classdef (Abstract) gibbonSettings
             end
         end
 
-        function reset()
-        % Revert to defaults (remove settings.GIBBON group)
-            s = settings;
-            if hasGroup(s,'GIBBON'), s.removeGroup('GIBBON'); end
+        function reset(varargin)
+        % gibbonSettings.reset() - remove settings.GIBBON group, and recreate with defaults
+        % gibbonSettings.reset('opt1', ...) - reset individual option(s) to default 
+
+            if nargin > 0
+                opts = cellfun(@(s) validatestring(s, gibbonSettings.names), varargin, 'unif', 0);
+            else
+                s = settings;
+                if hasGroup(s,'GIBBON'), s.removeGroup('GIBBON'); end
+                opts = gibbonSettings.names;
+            end
+
+            for j = 1:length(opts)
+                gibbonSettings.set(opts{j}, gibbonSettings.defaults.(opts{j}));
+            end
         end
 
         function p = findFEBioPath(defaultPaths)

--- a/lib/setViewProfile.m
+++ b/lib/setViewProfile.m
@@ -9,15 +9,12 @@ function setViewProfile(profileName)
 % 2023/05/25 Created by Kevin Moerman
 % ------------------------------------------------------------------------
 
-%% Parse input
-
-validSet={'default','CAD','febio','touchpad'};
-if ~ismember(profileName,validSet)    
-    error(""" Invalid profile type provided, use 'CAD','febio', or 'touchpad' """); 
+if strcmpi(profileName, 'default')
+    gibbonSettings.reset('ViewProfile');
+else
+    % Make/set view profile setting
+    gibbonSettings.set('ViewProfile', profileName);
 end
-
-%% Make view profile setting
-gibbonSettings.set('ViewProfile', profileName);
 
 end
 

--- a/tests/TEST_gibbonSettings.m
+++ b/tests/TEST_gibbonSettings.m
@@ -119,10 +119,19 @@ function testFindFEBioKeepsExisting(testCase)
     verifyEqual(testCase, p, testCase.TestData.dummyFEBio);
 end
 
-function testReset(testCase)
+function testResetSingle(testCase)
 
     gibbonSettings.set('view','touch','febio', testCase.TestData.dummyFEBio);
-    gibbonSettings.set('view','touch');
+    gibbonSettings.reset('view');
+    g = gibbonSettings.get();
+
+    verifyEqual(testCase, g.ViewProfile, gibbonSettings.defaults.ViewProfile);
+    verifyEqual(testCase, g.FEBioPath, testCase.TestData.dummyFEBio);
+end
+
+function testResetAll(testCase)
+
+    gibbonSettings.set('view','touch','febio', testCase.TestData.dummyFEBio);
 
     gibbonSettings.reset();
     g = gibbonSettings.get();

--- a/tests/TEST_vcw.m
+++ b/tests/TEST_vcw.m
@@ -1,0 +1,22 @@
+function tests = TEST_vcw
+    tests = functiontests(localfunctions);
+end
+
+function setup(testCase)
+    testCase.TestData.hf = figure();
+end
+
+function teardown(testCase)
+    if ishandle(testCase.TestData.hf)
+        close(testCase.TestData.hf);
+    end
+end
+
+function testViewProfiles(testCase)
+% Check that VCW recognizes all gibbonSettings.validViewProfiles
+
+    profiles = gibbonSettings.validViewProfiles;
+    for j = 1:length(profiles)
+        vcw(testCase.TestData.hf, profiles{j});
+    end
+end


### PR DESCRIPTION
Small suggestion after: f569c1bea7cf78ba65e62dcba115dc6365d35b5a

In the alias `setViewProfile.m`: `gibbonSettings.set('ViewProfile', profileName)`  already checks (and coerces) the `profileName` value to one of `gibbonSettings.validViewProfiles`, so there's no need to use `ismember(profileName,validSet)` again.

Notice I'm not including `'default'` as a valid value inside the `gibbonSettings` class (it might confuse and/or create conflicts with `gibbonSettings.default.ViewProfile`). To preserve the functionality of `setViewProfile('default')` I'm making it an alias for `gibbonSettings.reset('ViewProfile')`.

I've added some new tests to make sure `vcw` also keeps in sync with `gibbonSettings.validViewProfiles`.

 
 