### PR TITLE
fix: cleanup old paths during install

### DIFF
--- a/installGibbon.m
+++ b/installGibbon.m
@@ -40,6 +40,24 @@ function installGibbon(interactive, FEBioPath, profileNameVCW)
         mkdir(tempPath)
     end
 
+    %% Cleanup previous installs
+
+    % Make sure we restore the warning settings
+    ws = warning();
+    restoreWarnings = onCleanup(@() warning(ws));
+
+    if contains(path, gibbonSettings.gibbonPath)
+        updateStatus('Removing existing gibbon paths...');
+        warning('off','MATLAB:rmpath:DirNotFound')
+        rmpath(genpath(gibbonPath))
+
+        if contains(path, fullfile('gibbon','lib'))
+            warning(['A previous installation of GIBBON might still be present on the MATLAB path. '
+            'Please check your MATLAB path and remove any outdated GIBBON paths.']);
+        end
+        addpath(fullfile(gibbonPath,'lib'));
+    end
+
     %% Add paths
 
     top_statement = 'Adding gibbon paths. Please wait...';
@@ -50,7 +68,6 @@ function installGibbon(interactive, FEBioPath, profileNameVCW)
     addpath(pathNames{:})
 
     % Try to make sure we save the path...
-    ws = warning();
     warning('error','MATLAB:SavePath:PathNotSaved');
 
     try


### PR DESCRIPTION
Retroactive fix for bug addressed in: https://github.com/gibbonCode/GIBBON/commit/a953b9b2aba9be3c99768e179941c9e0357f5150
Should also help cleanup the path during version updates that change the folder structure. 