### PR TITLE
Troubleshoot codecov action

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -48,11 +48,12 @@ jobs:
           select-by-folder: tests
           strict: false
           test-results-html: test-results
-          code-coverage-cobertura: code-coverage/coverage.xml
+          code-coverage-cobertura: ./code-coverage/coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: code-coverage/coverage.xml
+          files: ./code-coverage/coverage.xml
           flags: matlab
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
Trying to figure out why the codecov badge is still not working. There was a problem uploading the coverage report, which should have been fixed, but Codecov still displays no coverage information (it might just be that we have to merge to master once).