### PR TITLE
CodeIssuesTask action

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           command: installGibbon
 
+      - name: Check Code-Issues
+        uses: matlab-actions/run-build@v3
+
       - name: Run tests
         uses: matlab-actions/run-tests@v3
         with:

--- a/buildfile.m
+++ b/buildfile.m
@@ -1,0 +1,9 @@
+function plan = buildfile
+import matlab.buildtool.tasks.*
+
+plan = buildplan(localfunctions);
+
+fc = matlab.buildtool.io.FileCollection.fromPaths(["docs/*.m", "lib/*.m", "tests/*.m"]);
+plan("check") = CodeIssuesTask(fc);
+plan.DefaultTasks = "check";
+end

--- a/docs/DEMO_febio_0059_face_mask_loading.m
+++ b/docs/DEMO_febio_0059_face_mask_loading.m
@@ -536,7 +536,7 @@ end
 
 [Fr1,Vr1]=roundMesh(indStart_Vm,Vm,Nm,nRim,maskRimFilletRadius);
 [Fr2,Vr2]=roundMesh(indEnd_Vm,Vm,Nm,nRim,maskRimFilletRadius);
-indEnd_Vr1=size(Vr1)-numPointsRimCurve+1:1:size(Vr1);
+indEnd_Vr1=size(Vr1,1) - numPointsRimCurve + 1:size(Vr1,1);
 indEnd_Vr2=fliplr(indEnd_Vr1);
 [Fr1,Vr1]=quad2tri(Fr1,Vr1,'a');
 [Fr2,Vr2]=quad2tri(Fr2,Vr2,'a');

--- a/resources/codeAnalyzerConfiguration.json
+++ b/resources/codeAnalyzerConfiguration.json
@@ -1,0 +1,23 @@
+// https://uk.mathworks.com/help/matlab/matlab_env/configure-code-analyzer.html
+// https://uk.mathworks.com/help/matlab/matlab_env/index-of-code-analyzer-checks.html
+{
+    "name": "GIBBON Guideline",
+    "guidelineVersion": "0.0.0",
+    "baseConfiguration": "factory",
+
+    "checks": {
+        "JAVFM": {
+            // JavaFrame was undocummented and has been removed
+            "severity": "warning"
+        },
+        "DisallowFindJObj": {
+            "rule": {
+                "template": "functionCall",
+                "functionNames": "findjobj"
+            },
+            "severity": "warning",
+            "messageText": "findjobj relies on JavaFrame, removed in R2025a",
+            "enabled": true
+        }
+    },
+}


### PR DESCRIPTION
Add a "build" step to the CI workflow, that runs the Code Analyser (`CodeIssuesTask`) and fails on errors. It should help keeping track of features of MATLAB that change over time. E.g. there's a couple of issues that used to be warnings, but became errors after R2025a:

- `docs/DEMO_febio_0059_face_mask_loading.m` used `1:size(Vr1)` where Vr1 is a 2D array, which now requires an explicit `1:size(Vr1,1)`
- `JavaFrame` has been dropped. I created a new issue for this (#213), for now I hard-set the severity of the error back to "warning" and added an additional check that should warn for future uses of `findjobj`.